### PR TITLE
bugfixes + additional dashboard info

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -80,6 +80,10 @@
         },
         "defaultPermission": {
           ".write": "!root.child($secretid).child('settings').child('defaultPermission').exists() || root.child($secretid).child('users').child(auth.uid).child('permission').val() === 'OWNER'"
+        },
+        "creationTime": {
+          /* only write upon creation */
+          ".write": "!root.child($secretid).child('settings').child('creationTime').exists()"
         }
       },
 

--- a/src/atoms/firebaseAtoms.ts
+++ b/src/atoms/firebaseAtoms.ts
@@ -143,6 +143,7 @@ export const joinNewWorkspaceAsOwnerAtom = atom(
         color: colorFromUserId(userRef.key),
         permission: 'OWNER',
       },
+      'settings/creationTime': firebase.database.ServerValue.TIMESTAMP,
       'settings/defaultPermission': 'READ_WRITE',
     });
   }

--- a/src/components/FilesGrid.tsx
+++ b/src/components/FilesGrid.tsx
@@ -8,8 +8,9 @@ export type File = {
   id: string;
   lastAccessTime: number;
   title: string;
-  lastPermission: string | null;
   creationTime: number | null;
+  lastPermission: string | null;
+  lastDefaultPermission: string | null;
 };
 
 export interface FilesGridProps {
@@ -18,6 +19,12 @@ export interface FilesGridProps {
 }
 
 import { permissionLabels } from '../components/UserList/UserListItem';
+
+export const sharingPermissionLabels: Record<string, string> = {
+  READ_WRITE: 'Public Read & Write',
+  READ: 'Public View Only',
+  PRIVATE: 'Private',
+};
 
 export default function FilesGrid(props: FilesGridProps): JSX.Element {
   const formatCreationTime = (creationTime: number | null): string => {
@@ -47,11 +54,19 @@ export default function FilesGrid(props: FilesGridProps): JSX.Element {
             <div className="text-gray-400">
               Created: {formatCreationTime(file.creationTime)}
             </div>
-            {props.showPerms && (
+            {props.showPerms ? (
               <div className="text-gray-400">
-                Sharing Permissions:{' '}
+                Permissions:{' '}
                 {file.lastPermission && file.lastPermission in permissionLabels
                   ? permissionLabels[file.lastPermission]
+                  : 'Unknown'}
+              </div>
+            ) : (
+              <div className="text-gray-400">
+                Default Permissions:{' '}
+                {file.lastDefaultPermission &&
+                file.lastDefaultPermission in sharingPermissionLabels
+                  ? sharingPermissionLabels[file.lastDefaultPermission]
                   : 'Unknown'}
               </div>
             )}

--- a/src/components/FilesGrid.tsx
+++ b/src/components/FilesGrid.tsx
@@ -8,27 +8,56 @@ export type File = {
   id: string;
   lastAccessTime: number;
   title: string;
+  lastPermission: string | null;
+  creationTime: number | null;
 };
 
 export interface FilesGridProps {
   files: File[];
+  showPerms: boolean;
 }
 
+import { permissionLabels } from '../components/UserList/UserListItem';
+
 export default function FilesGrid(props: FilesGridProps): JSX.Element {
+  const formatCreationTime = (creationTime: number | null): string => {
+    if (!creationTime) return 'Unknown';
+    // return String(creationTime);
+    // if recent then display time ago
+    if (+dayjs() - +dayjs(creationTime) <= 1000 * 60 * 60 * 24 * 2)
+      // <= two days
+      return dayjs(creationTime).fromNow();
+    return dayjs(creationTime).format('MM/DD/YYYY'); // otherwise display date
+  };
   return (
     <div className="mt-4 -mx-2">
-      {props.files.map(file => (
-        <Link
-          key={file.id}
-          to={`/${file.id.substring(1)}`}
-          className="bg-gray-800 hover:bg-gray-700 px-4 py-3 rounded-lg inline-block w-full max-w-sm m-2"
-        >
-          <div className="text-gray-200">{file.title || 'Unnamed File'}</div>
-          <div className="text-gray-400">
-            Last Accessed {dayjs(file.lastAccessTime).fromNow()}
-          </div>
-        </Link>
-      ))}
+      {props.files
+        .sort((a, b) => (a.creationTime ?? 0) - (b.creationTime ?? 0))
+        .reverse()
+        .map(file => (
+          <Link
+            key={file.id}
+            to={`/${file.id.substring(1)}`}
+            className="bg-gray-800 hover:bg-gray-700 px-4 py-3 rounded-lg inline-block w-full max-w-sm m-2"
+          >
+            <div className="text-gray-200">{file.title || 'Unnamed File'}</div>
+            <div className="text-gray-400">
+              Last Accessed: {dayjs(file.lastAccessTime).fromNow()}
+            </div>
+            <div className="text-gray-400">
+              Created: {formatCreationTime(file.creationTime)}
+            </div>
+            {props.showPerms && (
+              <div className="text-gray-400">
+                Sharing Permissions:{' '}
+                {file.lastPermission && file.lastPermission in permissionLabels
+                  ? permissionLabels[file.lastPermission]
+                  : 'Unknown'}
+              </div>
+            )}
+            {/* TODO: show default permissions otherwise */}
+          </Link>
+        ))}
     </div>
   );
 }

--- a/src/components/SettingsContext.tsx
+++ b/src/components/SettingsContext.tsx
@@ -40,6 +40,7 @@ export interface WorkspaceSettings {
   compilerOptions: { [key in Language]: string };
   defaultPermission: string;
   workspaceName?: string;
+  creationTime?: string;
 }
 
 type SettingsContextType = {

--- a/src/components/SharingPermissions.tsx
+++ b/src/components/SharingPermissions.tsx
@@ -8,7 +8,7 @@ const sharingOptions = [
     value: 'READ_WRITE',
   },
   {
-    label: 'View Only',
+    label: 'Public View Only',
     value: 'READ',
   },
   {
@@ -30,7 +30,7 @@ export const SharingPermissions = ({
     <>
       <RadioGroup value={value} onChange={onChange} disabled={!isOwner}>
         <RadioGroup.Label as="div" className="font-medium mb-2">
-          Sharing Permissions
+          Default Sharing Permissions
         </RadioGroup.Label>
         <div className="rounded-md space-y-2">
           {sharingOptions.map(setting => (

--- a/src/components/SharingPermissions.tsx
+++ b/src/components/SharingPermissions.tsx
@@ -20,13 +20,15 @@ const sharingOptions = [
 export const SharingPermissions = ({
   value,
   onChange,
+  isOwner,
 }: {
   value: string;
   onChange: (newVal: string) => void;
+  isOwner: boolean;
 }): JSX.Element => {
   return (
     <>
-      <RadioGroup value={value} onChange={onChange}>
+      <RadioGroup value={value} onChange={onChange} disabled={!isOwner}>
         <RadioGroup.Label as="div" className="font-medium mb-2">
           Sharing Permissions
         </RadioGroup.Label>

--- a/src/components/UserList/UserListItem.tsx
+++ b/src/components/UserList/UserListItem.tsx
@@ -16,7 +16,7 @@ import {
   authenticatedUserRefAtom,
 } from '../../atoms/firebaseAtoms';
 
-const permissionLabels = {
+export const permissionLabels: Record<string, string> = {
   OWNER: 'Owner',
   READ_WRITE: 'Read & Write',
   READ: 'View Only',

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -81,7 +81,20 @@ export const SettingsModal = ({
   };
 
   const saveAndClose = () => {
-    setRealWorkspaceSettings(workspaceSettings);
+    let settingsToSet: Partial<WorkspaceSettings> = workspaceSettings;
+    {
+      // don't override creation time
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { creationTime, ...toKeep } = settingsToSet;
+      settingsToSet = toKeep;
+    }
+    if (userPermission === 'READ_WRITE') {
+      // update has no effect if you try to overwrite default permission
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { defaultPermission, ...toKeep } = settingsToSet;
+      settingsToSet = toKeep;
+    }
+    setRealWorkspaceSettings(settingsToSet);
     editorModeAtom[1](editorMode);
     if (name !== firebaseUser?.displayName) {
       firebaseUser?.updateProfile({

--- a/src/components/settings/WorkspaceSettingsUI.tsx
+++ b/src/components/settings/WorkspaceSettingsUI.tsx
@@ -13,7 +13,7 @@ export default function WorkspaceSettingsUI({
 }): JSX.Element {
   return (
     <div className="space-y-6">
-      {userPermission === 'OWNER' && (
+      {
         <div>
           <label
             htmlFor={`workspace_name`}
@@ -29,14 +29,19 @@ export default function WorkspaceSettingsUI({
               className="mt-0 block w-full px-0 pt-0 pb-1 border-0 border-b-2 border-gray-200 focus:ring-0 focus:border-black text-sm"
               value={workspaceSettings.workspaceName || ''}
               onChange={e =>
+                (userPermission === 'OWNER' ||
+                  userPermission === 'READ_WRITE') &&
                 onWorkspaceSettingsChange({
                   workspaceName: e.target.value,
                 })
               }
+              disabled={
+                !(userPermission === 'OWNER' || userPermission === 'READ_WRITE')
+              }
             />
           </div>
         </div>
-      )}
+      }
 
       {LANGUAGES.map(({ label, value }) => (
         <div key={value}>
@@ -71,15 +76,14 @@ export default function WorkspaceSettingsUI({
           </div>
         </div>
       ))}
-
-      {userPermission === 'OWNER' && (
-        <SharingPermissions
-          value={workspaceSettings.defaultPermission}
-          onChange={val =>
-            onWorkspaceSettingsChange({ defaultPermission: val })
-          }
-        />
-      )}
+      <SharingPermissions
+        value={workspaceSettings.defaultPermission}
+        onChange={val =>
+          userPermission === 'OWNER' &&
+          onWorkspaceSettingsChange({ defaultPermission: val })
+        }
+        isOwner={userPermission === 'OWNER'}
+      />
     </div>
   );
 }

--- a/src/pages/CopyFilePage.tsx
+++ b/src/pages/CopyFilePage.tsx
@@ -34,13 +34,15 @@ export default function CopyFilePage(props: CopyFilePageProps): JSX.Element {
     ];
     Promise.all(keysToCopy.map(key => oldRef.child(key).once('value')))
       .then(async data => {
-        const updateObject: { [key: string]: unknown } = {};
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const updateObject: { [key: string]: any } = {};
         keysToCopy.forEach((key, idx) => {
           // we don't want to copy over user information or settings/defaultPermission for firepad
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { users, defaultPermission, ...toKeep } = data[idx].val() || {};
+          const { users, defaultPermission, creationTime, ...toKeep } = data[idx].val() || {};
           updateObject[key] = toKeep;
         });
+        updateObject['settings']['workspaceName'] += ' (Copy)'; // make sure to change the name
         await newRef.set(updateObject);
         setFileId({
           newId: newRef.key!.slice(1), // first character is dash which we want to ignore

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -68,7 +68,7 @@ export default function DashboardPage(
             <div className="h-12"></div>
 
             <h2 className="text-gray-100 text-xl md:text-3xl font-black">
-              Owned Files
+              Owned by You
             </h2>
             <FilesGrid files={ownedFiles} showPerms={false} />
           </>
@@ -79,7 +79,7 @@ export default function DashboardPage(
             <div className="h-12"></div>
 
             <h2 className="text-gray-100 text-xl md:text-3xl font-black">
-              Recently Accessed Files
+              Recently Accessed
             </h2>
             <FilesGrid files={files} showPerms={true} />
           </>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ export default function DashboardPage(
   _props: RouteComponentProps
 ): JSX.Element {
   const firebaseUser = useAtomValue(firebaseUserAtom);
+  const [ownedFiles, setOwnedFiles] = useState<File[] | null>(null);
   const [files, setFiles] = useState<File[] | null>(null);
 
   useEffect(() => {
@@ -23,15 +24,25 @@ export default function DashboardPage(
         if (!snap.exists) {
           setFiles(null);
         } else {
-          const newFiles: File[] = [];
+          const yourFiles: File[] = [];
           snap.forEach(child => {
-            newFiles.push({
+            yourFiles.push({
               id: child.key,
               ...child.val(),
             });
           });
-          newFiles.reverse();
-          setFiles(newFiles);
+          yourFiles.reverse();
+          const yourOwnedFiles: File[] = [];
+          const yourOtherFiles: File[] = [];
+          for (const file of yourFiles) {
+            if (file.lastPermission === 'OWNER') {
+              yourOwnedFiles.push(file);
+            } else {
+              yourOtherFiles.push(file);
+            }
+          }
+          setOwnedFiles(yourOwnedFiles);
+          setFiles(yourOtherFiles);
         }
       });
     return () => ref.off('value', unsubscribe);
@@ -52,15 +63,25 @@ export default function DashboardPage(
         >
           Create New File
         </Link>
+        {ownedFiles && ownedFiles.length > 0 && (
+          <>
+            <div className="h-12"></div>
+
+            <h2 className="text-gray-100 text-xl md:text-3xl font-black">
+              Owned Files
+            </h2>
+            <FilesGrid files={ownedFiles} showPerms={false} />
+          </>
+        )}
 
         {files && files.length > 0 && (
           <>
             <div className="h-12"></div>
 
             <h2 className="text-gray-100 text-xl md:text-3xl font-black">
-              Recently Accessed
+              Recently Accessed Files
             </h2>
-            <FilesGrid files={files} />
+            <FilesGrid files={files} showPerms={true} />
           </>
         )}
       </div>

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -258,26 +258,22 @@ export default function EditorPage(props: EditorPageProps): JSX.Element {
   useEffect(() => {
     if (permission === null) return;
     if (firebaseUser && fileId?.id) {
+      const fileRef = firebase
+        .database()
+        .ref('users')
+        .child(firebaseUser.uid)
+        .child(fileId.id);
       if (permission === 'PRIVATE') {
         // remove from recently accessed files
-        firebase
-          .database()
-          .ref('users')
-          .child(firebaseUser.uid)
-          .child(fileId.id)
-          .remove();
+        fileRef.remove();
       } else {
-        firebase
-          .database()
-          .ref('users')
-          .child(firebaseUser.uid)
-          .child(fileId.id)
-          .set({
-            title: settings.workspaceName || '',
-            lastAccessTime: firebase.database.ServerValue.TIMESTAMP,
-            creationTime: settings.creationTime ?? null,
-            lastPermission: permission,
-          });
+        fileRef.set({
+          title: settings.workspaceName || '',
+          lastAccessTime: firebase.database.ServerValue.TIMESTAMP,
+          creationTime: settings.creationTime ?? null,
+          lastPermission: permission,
+          lastDefaultPermission: settings.defaultPermission,
+        });
       }
     }
   }, [firebaseUser, fileId, settings.workspaceName]);

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -4,7 +4,7 @@ export const testRunCode = async (page: Page): Promise<void> => {
   await page.click('button:has-text("Run Code")');
   expect(await page.$('[data-test-id="run-code-loading"]')).toBeTruthy();
   await page.waitForSelector('button:has-text("Run Code")');
-  expect(await page.$('text=Accepted')).toBeTruthy();
+  expect(await page.$('text=Successful')).toBeTruthy();
   expect(await page.$('text="sum is 6"')).toBeTruthy();
 };
 


### PR DESCRIPTION
Changes:

 - changes "Accepted" -> "Successful"
 - private files no longer appear
 - fixes bug: users w/ read / write couldn't change file compiler settings
 - displays more info on dashboard (including creation time)
 - sorts files on dashboard by creation time (newest first)
   - seems preferable for files to be displayed in a consistent order
   - oops, bugged for files which haven't been assigned a creation time. they are assigned a creation time upon access
 - display settings to all users (why not?)
 - display default permissions for files you own on the dashboard
 
Todo:

 - radio options should not be selectable for non-owners (it is disabled right now, but it doesn't prevent them from being selected. not sure why this is the case)
 - creation time probably doesn't belong in settings but it seems to work
 - test (haven't tested after merge, will try tomorrow)
 - automated tests

Nice to have in the future?

 - non-anonymous login
 - allow removing files from dashboard (perhaps these should still hang around in a separate section of the dashboard for a few days or so in case you removed it by accident?)
 - shorter URLs for easier sharing