### PR TITLE
parse samples, run on one or all samples

### DIFF
--- a/src/atoms/workspaceUI.ts
+++ b/src/atoms/workspaceUI.ts
@@ -1,6 +1,39 @@
 import { atom } from 'jotai';
 import { JudgeSuccessResult } from '../types/judge';
+import { ProblemData } from '../components/Workspace/Workspace';
 
 export const mobileActiveTabAtom = atom<'code' | 'io' | 'users'>('code');
 export const showSidebarAtom = atom<boolean>(false);
-export const judgeResultAtom = atom<JudgeSuccessResult | null>(null);
+export const judgeResultsAtom = atom<(JudgeSuccessResult | null)[]>([]);
+export const inputTabAtom = atom<string>('input');
+export const problemDataAtom = atom<ProblemData | null | undefined>(undefined);
+export const tabsListAtom = atom(get => {
+  const getSamplesList = (length: number) => {
+    const res = [];
+    if (length === 1) {
+      res.push({ label: `Sample`, value: `Sample` });
+    } else {
+      // only number samples if >1
+      for (let i = 1; i <= length; ++i)
+        res.push({ label: `Sample ${i}`, value: `Sample ${i}` });
+    }
+    return res;
+  };
+  const problemData = get(problemDataAtom);
+  return [
+    { label: 'Input', value: 'input' },
+    ...(problemData !== undefined
+      ? [{ label: 'USACO Judge', value: 'judge' }]
+      : []),
+    ...(problemData?.samples
+      ? getSamplesList(problemData?.samples.length)
+      : []),
+  ];
+});
+export const inputTabIndexAtom = atom(get => {
+  const inputTab = get(inputTabAtom);
+  const tabsList = get(tabsListAtom);
+  let res = 0;
+  while (res < tabsList.length && tabsList[res].value !== inputTab) ++res;
+  return res;
+});

--- a/src/components/JudgeInterface/JudgeInterface.tsx
+++ b/src/components/JudgeInterface/JudgeInterface.tsx
@@ -4,6 +4,8 @@ import { currentLangAtom, mainMonacoEditorAtom } from '../../atoms/workspace';
 import USACOResults from './USACOResults';
 import { ProblemData, StatusData } from '../Workspace/Workspace';
 import SubmitButton from './SubmitButton';
+import { PlayIcon } from '@heroicons/react/solid';
+import { Sample } from './Samples';
 
 // export const judgePrefix = 'http://localhost:5000';
 export const judgePrefix = 'https://judge.usaco.guide';
@@ -38,8 +40,15 @@ export default function JudgeInterface(props: {
   problemData: ProblemData | null | undefined;
   statusData: StatusData | null;
   setStatusData: React.Dispatch<React.SetStateAction<StatusData | null>>;
+  runAllSamples: (samples: Sample[]) => Promise<void>;
 }): JSX.Element {
-  const { problemID, problemData, statusData, setStatusData } = props;
+  const {
+    problemID,
+    problemData,
+    statusData,
+    setStatusData,
+    runAllSamples,
+  } = props;
   const mainMonacoEditor = useAtomValue(mainMonacoEditorAtom);
   const lang = useAtomValue(currentLangAtom);
 
@@ -84,66 +93,81 @@ export default function JudgeInterface(props: {
     setTimeout(checkStatus, 1000);
   };
 
+  // console.log('SAMPLES ' + problemData?.samples);
   return (
     <div className="relative h-full flex flex-col">
-      <div className="p-4 pb-0">
-        {problemData && problemData.parsed ? (
-          <>
-            <p className="text-gray-100 font-bold text-lg">
-              <a
-                href={getUSACOContestURL(problemData.source || '')}
-                className="text-indigo-300"
-                target="_blank"
-                rel="noreferrer"
+      <div className="flex-1 overflow-y-auto">
+        <div className="p-4 pb-0">
+          <p className="text-gray-400 text-sm mb-4">
+            Early access. Report issues to Github. Do not spam submit.
+            {/* Note: You will not be able to submit to a problem in an active contest. */}
+            {/* ^ is this necessary? */}
+          </p>
+          {problemData && problemData.parsed ? (
+            <>
+              <p className="text-gray-100 font-bold text-lg">
+                <a
+                  href={getUSACOContestURL(problemData.source || '')}
+                  className="text-indigo-300"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {problemData?.source}
+                </a>
+              </p>
+              <p className="text-gray-100 font-bold text-lg">
+                <a
+                  href={`http://www.usaco.org/index.php?page=viewproblem2&cpid=${problemID}`}
+                  className="text-indigo-300"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {problemData?.title}
+                </a>
+              </p>
+              <p className="text-gray-100 text-sm mb-4">
+                <span className="font-bold">I/O:</span> {problemData?.input}/
+                {problemData?.output}
+              </p>
+              {/* <p className="text-gray-100 text-sm">
+                <span className="font-bold">INPUT:</span> {problemData?.input}
+              </p>
+              <p className="text-gray-100 text-sm">
+                <span className="font-bold">OUTPUT:</span> {problemData?.output}
+              </p> */}
+              <button
+                type="button"
+                className="relative flex-shrink-0 inline-flex items-center px-4 py-2 w-40 shadow-sm text-sm font-medium text-white bg-indigo-900 hover:bg-indigo-800 focus:bg-indigo-800 focus:outline-none"
+                onClick={() => runAllSamples(problemData?.samples ?? [])}
               >
-                {problemData?.source}
-              </a>
-            </p>
-            <p className="text-gray-100 font-bold text-lg">
-              <a
-                href={`http://www.usaco.org/index.php?page=viewproblem2&cpid=${problemID}`}
-                className="text-indigo-300"
-                target="_blank"
-                rel="noreferrer"
-              >
-                {problemData?.title}
-              </a>
-            </p>
-            <p className="text-gray-100 text-sm">
-              <span className="font-bold">INPUT:</span> {problemData?.input}
-            </p>
-            <p className="text-gray-100 text-sm">
-              <span className="font-bold">OUTPUT:</span> {problemData?.output}
-            </p>
-          </>
-        ) : (
-          <>
-            <p className="text-gray-100 font-bold text-lg">
-              USACO Problem ID:{' '}
-              <a
-                href={`http://www.usaco.org/index.php?page=viewproblem2&cpid=${problemID}`}
-                className="text-indigo-300"
-                target="_blank"
-                rel="noreferrer"
-              >
-                {problemID}
-              </a>
-            </p>
-            <p className="text-red-300 text-sm font-bold">
-              {problemData
-                ? 'Could not parse problem data.'
-                : 'Problem ID does not exist.'}
-            </p>
-          </>
-        )}
-        <p className="text-gray-400 text-sm">
-          Early access. Report issues to Github. Do not spam submit.
-          {/* Note: You will not be able to submit to a problem in an active contest. */}
-          {/* ^ is this necessary? */}
-        </p>
-      </div>
-      <div className="flex-1 overflow-y-auto px-4">
-        <USACOResults data={statusData} />
+                <PlayIcon className="mr-2 h-5 w-5" aria-hidden="true" />
+                <span className="text-center flex-1">Run Samples</span>
+              </button>
+            </>
+          ) : (
+            <>
+              <p className="text-gray-100 font-bold text-lg">
+                USACO Problem ID:{' '}
+                <a
+                  href={`http://www.usaco.org/index.php?page=viewproblem2&cpid=${problemID}`}
+                  className="text-indigo-300"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {problemID}
+                </a>
+              </p>
+              <p className="text-red-300 text-sm font-bold">
+                {problemData
+                  ? 'Could not parse problem data.'
+                  : 'Problem ID does not exist.'}
+              </p>
+            </>
+          )}
+        </div>
+        <div className="px-4">
+          <USACOResults data={statusData} />
+        </div>
       </div>
       <SubmitButton
         isLoading={(statusData?.statusCode ?? 0) <= -8}

--- a/src/components/JudgeInterface/JudgeInterface.tsx
+++ b/src/components/JudgeInterface/JudgeInterface.tsx
@@ -6,8 +6,8 @@ import { ProblemData, StatusData } from '../Workspace/Workspace';
 import SubmitButton from './SubmitButton';
 import { PlayIcon } from '@heroicons/react/solid';
 
-export const judgePrefix = 'http://localhost:5000';
-// export const judgePrefix = 'https://judge.usaco.guide';
+// export const judgePrefix = 'http://localhost:5000';
+export const judgePrefix = 'https://judge.usaco.guide';
 
 function encode(str: string | null) {
   return btoa(unescape(encodeURIComponent(str || '')));

--- a/src/components/JudgeInterface/JudgeInterface.tsx
+++ b/src/components/JudgeInterface/JudgeInterface.tsx
@@ -5,10 +5,9 @@ import USACOResults from './USACOResults';
 import { ProblemData, StatusData } from '../Workspace/Workspace';
 import SubmitButton from './SubmitButton';
 import { PlayIcon } from '@heroicons/react/solid';
-import { Sample } from './Samples';
 
-// export const judgePrefix = 'http://localhost:5000';
-export const judgePrefix = 'https://judge.usaco.guide';
+export const judgePrefix = 'http://localhost:5000';
+// export const judgePrefix = 'https://judge.usaco.guide';
 
 function encode(str: string | null) {
   return btoa(unescape(encodeURIComponent(str || '')));
@@ -40,14 +39,14 @@ export default function JudgeInterface(props: {
   problemData: ProblemData | null | undefined;
   statusData: StatusData | null;
   setStatusData: React.Dispatch<React.SetStateAction<StatusData | null>>;
-  runAllSamples: (samples: Sample[]) => Promise<void>;
+  handleRunCode: () => void;
 }): JSX.Element {
   const {
     problemID,
     problemData,
     statusData,
     setStatusData,
-    runAllSamples,
+    handleRunCode,
   } = props;
   const mainMonacoEditor = useAtomValue(mainMonacoEditorAtom);
   const lang = useAtomValue(currentLangAtom);
@@ -138,7 +137,7 @@ export default function JudgeInterface(props: {
               <button
                 type="button"
                 className="relative flex-shrink-0 inline-flex items-center px-4 py-2 w-40 shadow-sm text-sm font-medium text-white bg-indigo-900 hover:bg-indigo-800 focus:bg-indigo-800 focus:outline-none"
-                onClick={() => runAllSamples(problemData?.samples ?? [])}
+                onClick={handleRunCode}
               >
                 <PlayIcon className="mr-2 h-5 w-5" aria-hidden="true" />
                 <span className="text-center flex-1">Run Samples</span>

--- a/src/components/JudgeInterface/Samples.tsx
+++ b/src/components/JudgeInterface/Samples.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { PlayIcon } from '@heroicons/react/solid';
+
+export interface Sample {
+  input: string;
+  output: string;
+}
+
+export default function Samples({
+  samples,
+  inputTab,
+  handleRunCode,
+}: {
+  samples: Sample[];
+  inputTab: string;
+  handleRunCode: (
+    input: string,
+    expectedOutput?: string | undefined,
+    prefix?: string | undefined
+  ) => void;
+}): JSX.Element {
+  const index = inputTab.length === 6 ? 1 : +inputTab.substring(7);
+  const sample = samples[index - 1];
+
+  return (
+    <p className="text-sm">
+      <button
+        type="button"
+        className="relative flex-shrink-0 inline-flex items-center px-4 py-2 w-40 shadow-sm text-sm font-medium text-white bg-indigo-900 hover:bg-indigo-800 focus:bg-indigo-800 focus:outline-none"
+        onClick={() =>
+          handleRunCode(sample.input, sample.output, inputTab + ': ')
+        }
+      >
+        <PlayIcon className="mr-2 h-5 w-5" aria-hidden="true" />
+        <span className="text-center flex-1">Run {inputTab}</span>
+      </button>
+      <p className="font-bold mt-4">INPUT:</p>
+      <pre className="-mx-4 sm:-mx-6 md:mx-0 md:rounded p-4 mt-4 mb-4 whitespace-pre-wrap break-all bg-gray-700">
+        {sample.input}
+      </pre>
+      <p className="font-bold">OUTPUT:</p>
+      <pre className="-mx-4 sm:-mx-6 md:mx-0 md:rounded p-4 mt-4 mb-4 whitespace-pre-wrap break-all bg-gray-700">
+        {sample.output}
+      </pre>
+    </p>
+  );
+}

--- a/src/components/JudgeInterface/Samples.tsx
+++ b/src/components/JudgeInterface/Samples.tsx
@@ -6,6 +6,10 @@ export interface Sample {
   output: string;
 }
 
+export function getSampleIndex(inputTab: string): number {
+  return inputTab.length === 6 ? 1 : +inputTab.substring(7);
+}
+
 export default function Samples({
   samples,
   inputTab,
@@ -13,23 +17,17 @@ export default function Samples({
 }: {
   samples: Sample[];
   inputTab: string;
-  handleRunCode: (
-    input: string,
-    expectedOutput?: string | undefined,
-    prefix?: string | undefined
-  ) => void;
+  handleRunCode: () => void;
 }): JSX.Element {
-  const index = inputTab.length === 6 ? 1 : +inputTab.substring(7);
+  const index = getSampleIndex(inputTab);
   const sample = samples[index - 1];
 
   return (
-    <p className="text-sm">
+    <div className="text-sm">
       <button
         type="button"
         className="relative flex-shrink-0 inline-flex items-center px-4 py-2 w-40 shadow-sm text-sm font-medium text-white bg-indigo-900 hover:bg-indigo-800 focus:bg-indigo-800 focus:outline-none"
-        onClick={() =>
-          handleRunCode(sample.input, sample.output, inputTab + ': ')
-        }
+        onClick={handleRunCode}
       >
         <PlayIcon className="mr-2 h-5 w-5" aria-hidden="true" />
         <span className="text-center flex-1">Run {inputTab}</span>
@@ -42,6 +40,6 @@ export default function Samples({
       <pre className="-mx-4 sm:-mx-6 md:mx-0 md:rounded p-4 mt-4 mb-4 whitespace-pre-wrap break-all bg-gray-700">
         {sample.output}
       </pre>
-    </p>
+    </div>
   );
 }

--- a/src/components/JudgeInterface/USACOResults.tsx
+++ b/src/components/JudgeInterface/USACOResults.tsx
@@ -66,8 +66,11 @@ export default function USACOResults({
       }
       answers.push(ans);
     }
-    output = lines.join('\n');
     equalUpToTrim = answers[0].trim() === answers[1].trim();
+    if (equalUpToTrim) {
+      // display whitespace
+      output = lines.join('\n');
+    }
   }
   return (
     <div className="mt-3">

--- a/src/components/JudgeInterface/USACOResults.tsx
+++ b/src/components/JudgeInterface/USACOResults.tsx
@@ -61,7 +61,7 @@ export default function USACOResults({
         continue;
       let ans = '';
       for (let j = indices[i] + 1; j < indices[i + 1] - 1; ++j) {
-        ans += lines[j] + '\n';
+        ans += lines[j].trim() + '\n';
         lines[j] = lines[j].replace(/ /g, '\u2423'); // make spaces visible
       }
       answers.push(ans);

--- a/src/components/Workspace/Workspace.tsx
+++ b/src/components/Workspace/Workspace.tsx
@@ -152,7 +152,7 @@ export default function Workspace({
   };
   useEffect(() => {
     updateProblemData(settings.judgeUrl);
-  });
+  }, [settings.judgeUrl]);
 
   const inputTabIndex = useAtomValue(inputTabIndexAtom);
 

--- a/src/pages/editorUtils.ts
+++ b/src/pages/editorUtils.ts
@@ -1,0 +1,55 @@
+import { JudgeResult } from '../types/judge';
+
+export function encode(str: string | null): string {
+  return btoa(unescape(encodeURIComponent(str || '')));
+}
+
+function decode(bytes: string | null): string {
+  const escaped = escape(atob(bytes || ''));
+  try {
+    return decodeURIComponent(escaped);
+  } catch (err) {
+    return unescape(escaped);
+  }
+}
+
+function cleanAndReplaceOutput(
+  output: string
+): { replaced: string; cleaned: string } {
+  const replaced = output.replace(/ /g, '\u2423'); // spaces made visible
+  const lines = output.split('\n');
+  for (let i = 0; i < lines.length; ++i) lines[i] = lines[i].trim();
+  const cleaned = lines.join('\n').trim(); // remove leading / trailing whitespace on each line, trim
+  return { replaced, cleaned };
+}
+
+export function cleanJudgeResult(
+  data: JudgeResult,
+  expectedOutput?: string,
+  prefix?: string
+): void {
+  // cleans up in place
+  data.stdout = decode(data.stdout);
+  data.stderr = decode(data.stderr);
+  data.compile_output = decode(data.compile_output);
+  data.message = decode(data.message);
+  if (!expectedOutput) {
+    if (data.status.description == 'Accepted')
+      data.status.description = 'Successful';
+  } else {
+    if (!data.stdout.endsWith('\n')) data.stdout += '\n';
+    const { cleaned, replaced } = cleanAndReplaceOutput(data.stdout);
+    if (data.status.id === 3 && data.stdout !== expectedOutput) {
+      data.status.id = 4;
+      if (cleaned === expectedOutput.trim()) {
+        data.status.description = 'Wrong Answer (Extra Whitespace)';
+        data.stdout = replaced; // show the extra whitespace
+      } else {
+        data.status.description = 'Wrong Answer';
+      }
+    }
+  }
+  if (prefix && !data.status.description.includes('Compilation'))
+    // only add prefix when no compilation error
+    data.status.description = prefix + data.status.description;
+}

--- a/src/types/judge.d.ts
+++ b/src/types/judge.d.ts
@@ -5,6 +5,7 @@ export interface JudgeSuccessResult {
   compile_output: string;
   message: string;
   status: {
+    id: number;
     description: string;
   };
   time: string;


### PR DESCRIPTION
at some point, should modify the callback for the run code button such that it runs the currently selected input tab. 
Closes #16 

i.e.,

- [x]  if you have a sample tab open, you will run that sample
- [x] if you have the judge tab open, you will run all samples

store verdicts and outputs separately for every sample? Switching tabs would switch the output as well.