### PR TITLE
Remove usaco id map from dashboard

### DIFF
--- a/src/components/WorkspaceInitializer.tsx
+++ b/src/components/WorkspaceInitializer.tsx
@@ -39,7 +39,7 @@ if (typeof window !== 'undefined') {
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 export const shouldUseEmulator =
-  typeof window !== 'undefined' && location.hostname === 'localhost' && false;
+  typeof window !== 'undefined' && location.hostname === 'localhost';
 
 if (!firebase.apps?.length) {
   if (shouldUseEmulator) {

--- a/src/components/WorkspaceInitializer.tsx
+++ b/src/components/WorkspaceInitializer.tsx
@@ -39,7 +39,7 @@ if (typeof window !== 'undefined') {
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 export const shouldUseEmulator =
-  typeof window !== 'undefined' && location.hostname === 'localhost';
+  typeof window !== 'undefined' && location.hostname === 'localhost' && false;
 
 if (!firebase.apps?.length) {
   if (shouldUseEmulator) {

--- a/src/pages/CopyFilePage.tsx
+++ b/src/pages/CopyFilePage.tsx
@@ -4,6 +4,7 @@ import { fileIdAtom } from '../atoms/firebaseAtoms';
 import firebase from 'firebase/app';
 import { navigate, RouteComponentProps } from '@reach/router';
 import { MessagePage } from '../components/MessagePage';
+import { isFirebaseId } from './editorUtils';
 
 export interface CopyFilePageProps extends RouteComponentProps {
   fileId?: string;
@@ -14,10 +15,9 @@ export default function CopyFilePage(props: CopyFilePageProps): JSX.Element {
   const [permissionDenied, setPermissionDenied] = useState(false);
 
   useEffect(() => {
-    let queryId: string | null = props.fileId ?? null;
+    const queryId: string = props.fileId ?? '';
 
-    if (queryId?.length !== 19) {
-      queryId = null;
+    if (!isFirebaseId(queryId)) {
       alert('Error: Bad URL');
       navigate('/', { replace: true });
       return;

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -9,6 +9,7 @@ import {
   signInWithGoogleAtom,
   signOutAtom,
 } from '../atoms/firebaseUserAtoms';
+import { isFirebaseId } from './editorUtils';
 
 export default function DashboardPage(
   _props: RouteComponentProps
@@ -32,9 +33,10 @@ export default function DashboardPage(
         } else {
           const yourFiles: File[] = [];
           snap.forEach(child => {
-            if (child.key !== 'usaco-id-to-url') {
+            const key = child.key;
+            if (key?.startsWith('-') && isFirebaseId(key.substring(1))) {
               yourFiles.push({
-                id: child.key,
+                id: key,
                 ...child.val(),
               });
             }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -32,10 +32,12 @@ export default function DashboardPage(
         } else {
           const yourFiles: File[] = [];
           snap.forEach(child => {
-            yourFiles.push({
-              id: child.key,
-              ...child.val(),
-            });
+            if (child.key !== 'usaco-id-to-url') {
+              yourFiles.push({
+                id: child.key,
+                ...child.val(),
+              });
+            }
           });
           yourFiles.reverse();
           const yourOwnedFiles: File[] = [];

--- a/src/pages/EditorPage.tsx
+++ b/src/pages/EditorPage.tsx
@@ -47,7 +47,7 @@ import {
   tabsListAtom,
   inputTabIndexAtom,
 } from '../atoms/workspaceUI';
-import { encode, cleanJudgeResult } from './editorUtils';
+import { encode, cleanJudgeResult, isFirebaseId } from './editorUtils';
 
 import { getSampleIndex } from '../components/JudgeInterface/Samples';
 import { firebaseUserAtom } from '../atoms/firebaseUserAtoms';
@@ -79,16 +79,14 @@ export default function EditorPage(props: EditorPageProps): JSX.Element {
   const problem = useAtomValue(problemAtom);
 
   useEffect(() => {
-    const queryId: string | null = props.fileId ?? null;
+    const queryId: string = props.fileId ?? '';
 
     if (queryId === 'new') {
       setFileId({
         newId: null,
         isNewFile: true,
       });
-      // validate that queryId is a firebase key
-      // todo improve: https://stackoverflow.com/questions/52850099/what-is-the-reg-expression-for-firestore-constraints-on-document-ids/52850529#52850529
-    } else if (queryId?.length === 19) {
+    } else if (isFirebaseId(queryId)) {
       if (fileId?.id !== '-' + queryId) {
         setFileId({
           newId: queryId,

--- a/src/pages/editorUtils.ts
+++ b/src/pages/editorUtils.ts
@@ -13,6 +13,13 @@ function decode(bytes: string | null): string {
   }
 }
 
+// ex. MdDtPWrb3oOcNKtIVEA
+// validate that queryId is a firebase key
+// todo improve: https://stackoverflow.com/questions/52850099/what-is-the-reg-expression-for-firestore-constraints-on-document-ids/52850529#52850529
+export function isFirebaseId(queryId: string): boolean {
+  return queryId.length === 19;
+}
+
 function cleanAndReplaceOutput(
   output: string
 ): { replaced: string; cleaned: string } {


### PR DESCRIPTION
the `usaco-id-to-url` map shows up as a file on the dashboard

![image](https://user-images.githubusercontent.com/63619830/124161341-24880700-da52-11eb-931f-d7951923d468.png)
