### PR TITLE
tab size in user settings

### DIFF
--- a/src/atoms/userSettings.ts
+++ b/src/atoms/userSettings.ts
@@ -41,6 +41,7 @@ export const userSettingsRefAtom = atom<firebaseType.database.Reference | null>(
 interface UserSettings {
   color: string;
   editorMode: EditorMode;
+  tabSize: number;
   defaultPermission: DefaultPermission;
   defaultLang: Language;
 }
@@ -48,6 +49,7 @@ interface UserSettings {
 export const defaultUserSettings: UserSettings = {
   editorMode: 'Normal', // change in settings
   color: '', // fixed
+  tabSize: 4,
   defaultPermission: 'READ_WRITE', // change in dashboard
   defaultLang: 'cpp', // last viewed file
 };

--- a/src/components/CodeInterface/CodeInterface.tsx
+++ b/src/components/CodeInterface/CodeInterface.tsx
@@ -12,6 +12,7 @@ import {
 import { LazyFirepadEditor } from '../LazyFirepadEditor';
 import { useAtomValue } from 'jotai/utils';
 import { authenticatedFirebaseRefAtom } from '../../atoms/firebaseAtoms';
+import { userSettingsAtomWithPersistence } from '../../atoms/userSettings';
 
 export const CodeInterface = ({
   className,
@@ -46,6 +47,8 @@ export const CodeInterface = ({
     }
   }, [editor, setMainMonacoEditor]);
 
+  const { tabSize } = useAtomValue(userSettingsAtomWithPersistence);
+
   return (
     <div
       className={classNames(
@@ -70,6 +73,7 @@ export const CodeInterface = ({
           options={{
             minimap: { enabled: false },
             automaticLayout: false,
+            tabSize: tabSize,
             insertSpaces: false,
             readOnly,
           }}

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -75,6 +75,7 @@ export const SettingsModal = ({
   const [userPermission] = useAtom(actualUserPermissionAtom);
   const [name, setName] = useState<string>('');
   const [editorMode, setEditorMode] = useState<EditorMode>('Normal');
+  const [tabSize, setTabSize] = useState<number>(4);
   const [userSettings, setUserSettings] = useAtom(
     userSettingsAtomWithPersistence
   );
@@ -86,6 +87,7 @@ export const SettingsModal = ({
       setWorkspaceSettings(realWorkspaceSettings);
       setName(actualDisplayName);
       setEditorMode(userSettings.editorMode);
+      setTabSize(userSettings.tabSize);
       dirtyRef.current = false;
       setTab('workspace');
     }
@@ -123,7 +125,7 @@ export const SettingsModal = ({
       settingsToSet = toKeep;
     }
     setRealWorkspaceSettings(settingsToSet);
-    setUserSettings({ editorMode });
+    setUserSettings({ editorMode, tabSize });
     if (name !== actualDisplayName) {
       setDisplayName(name);
       userRef?.child('name').set(name);
@@ -217,6 +219,11 @@ export const SettingsModal = ({
                     editorMode={editorMode}
                     onEditorModeChange={mode => {
                       setEditorMode(mode);
+                      dirtyRef.current = true;
+                    }}
+                    tabSize={tabSize}
+                    onTabSizeChange={size => {
+                      setTabSize(size);
                       dirtyRef.current = true;
                     }}
                   />

--- a/src/components/settings/UserSettings.tsx
+++ b/src/components/settings/UserSettings.tsx
@@ -9,11 +9,15 @@ export default function UserSettings({
   onNameChange,
   editorMode,
   onEditorModeChange,
+  tabSize,
+  onTabSizeChange,
 }: {
   name: string;
   onNameChange: (name: string) => void;
   editorMode: EditorMode;
   onEditorModeChange: (mode: EditorMode) => void;
+  tabSize: number;
+  onTabSizeChange: (tabSize: number) => void;
 }): JSX.Element {
   return (
     <div className="space-y-6">
@@ -42,6 +46,51 @@ export default function UserSettings({
           </RadioGroup.Label>
           <div className="bg-white rounded-md space-x-4">
             {EDITOR_MODES.map(setting => (
+              <RadioGroup.Option
+                key={setting}
+                value={setting}
+                className="relative inline-flex items-center cursor-pointer focus:outline-none"
+              >
+                {({ active, checked }) => (
+                  <>
+                    <span
+                      className={classNames(
+                        checked
+                          ? 'bg-indigo-600 border-transparent'
+                          : 'bg-white border-gray-300',
+                        active ? 'ring-2 ring-offset-2 ring-indigo-500' : '',
+                        'h-4 w-4 mt-0.5 cursor-pointer rounded-full border flex items-center justify-center'
+                      )}
+                      aria-hidden="true"
+                    >
+                      <span className="rounded-full bg-white w-1.5 h-1.5" />
+                    </span>
+                    <div className="ml-2 flex flex-col">
+                      <RadioGroup.Label
+                        as="span"
+                        className={classNames(
+                          checked ? 'text-gray-800' : 'text-gray-600',
+                          'block text-sm font-medium'
+                        )}
+                      >
+                        {setting}
+                      </RadioGroup.Label>
+                    </div>
+                  </>
+                )}
+              </RadioGroup.Option>
+            ))}
+          </div>
+        </RadioGroup>
+      </div>
+
+      <div>
+        <RadioGroup value={tabSize} onChange={onTabSizeChange}>
+          <RadioGroup.Label className="font-medium text-gray-800 mb-4">
+            Tab Size
+          </RadioGroup.Label>
+          <div className="bg-white rounded-md space-x-4">
+            {[2, 4, 8].map(setting => (
               <RadioGroup.Option
                 key={setting}
                 value={setting}


### PR DESCRIPTION
Adds tab width (2, 4, or 8) to user settings. Partially addresses #56.

One weird thing I noticed: It doesn't seem to be possible to have different values of `insertSpaces` for each of the three editors (code, input, and scribble). Specifically, if `insertSpaces` is set to `false` on any one of them, then it will effectively be set to `false` for all of them. Is this a bug?