### PR TITLE
improvement: added regex check to Firebase Id checking

### DIFF
--- a/src/editorUtils.ts
+++ b/src/editorUtils.ts
@@ -5,8 +5,10 @@ export function encode(str: string | null): string {
 }
 
 export function isFirebaseId(queryId: string): boolean {
-  const re = /^(?!\.\.?$)(?!.*__.*__)([^/]{1,1500})$/;
-  return re.test(queryId) && queryId.length === 19;
+  return (
+    /^(?!\.\.?$)(?!.*__.*__)([^/]{1,1500})$/.test(queryId) &&
+    queryId.length === 19
+  );
 }
 
 function cleanAndReplaceOutput(output: string): {

--- a/src/editorUtils.ts
+++ b/src/editorUtils.ts
@@ -4,11 +4,9 @@ export function encode(str: string | null): string {
   return btoa(unescape(encodeURIComponent(str || '')));
 }
 
-// ex. MdDtPWrb3oOcNKtIVEA
-// validate that queryId is a firebase key
-// todo improve: https://stackoverflow.com/questions/52850099/what-is-the-reg-expression-for-firestore-constraints-on-document-ids/52850529#52850529
 export function isFirebaseId(queryId: string): boolean {
-  return queryId.length === 19;
+  const re = /^(?!\.\.?$)(?!.*__.*__)([^/]{1,1500})$/;
+  return re.test(queryId) && queryId.length === 19;
 }
 
 function cleanAndReplaceOutput(output: string): {


### PR DESCRIPTION
I found a todo on the function isFirebaseId where a possible implementation of regex verification was linked above.
```// ex. MdDtPWrb3oOcNKtIVEA
// validate that queryId is a firebase key
// todo improve: https://stackoverflow.com/questions/52850099/what-is-the-reg-expression-for-firestore-constraints-on-document-ids/52850529#52850529
export function isFirebaseId(queryId: string): boolean {
  return queryId.length === 19;
}
```
So I just implemented the regex statement and still included the length check from before to better verify firebase keys.

I tested this with the sample id given (MdDtPWrb3oOcNKtIVEA) and it worked.
