### PR TITLE
fix for settings-modal displacement 

### DIFF
--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -180,7 +180,7 @@ export const SettingsModal = ({
       <Dialog
         as="div"
         static
-        className="fixed z-10 inset-0 overflow-y-auto"
+        className="fixed z-10 inset-0 overflow-y-scroll no-scrollbar"
         open={isOpen}
         onClose={() => closeWithoutSaving()}
       >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -45,3 +45,11 @@ html {
   outline: none;
   --tw-ring-color: transparent !important;
 }
+
+/* This hides the scrollbar */
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+.no-scrollbar {
+  scrollbar-width: none;
+}


### PR DESCRIPTION
### Summary

This PR hides the scrollbar in the settings modal while preserving the scroll functionality. This change ensures that the modal remains in place when switching between tabs with different content heights.

### Changes

- Added `.no-scrollbar` class to hide the scrollbar.
- Changed tailwindcss class from `overflow-y-auto` to `overflow-y-scroll` in the settings modal.
- Updated `SettingsModal.tsx` and `globals.css`.

### Testing

- Verified that the modal does not displace when switching between tabs.
- Ensured that scrolling functionality is maintained within the modal.
- The fix also supported by all major browsers

### Related Issues

Fixes issue #156