### PR TITLE
Remove extra "fork" in nouns section

### DIFF
--- a/src/routes/new/generateRandomFileName.ts
+++ b/src/routes/new/generateRandomFileName.ts
@@ -68,7 +68,6 @@ const nouns = [
 	'shower',
 	'window',
 	'umbrella',
-	'fork',
 	'plant',
 	'towel'
 ];


### PR DESCRIPTION
Removes the extra fork in the nouns section for the generateRandomFileName.