### PR TITLE
Fix: Trim trailing whitespace from getline input

### DIFF
--- a/src/routes/[id]/IDE.svelte
+++ b/src/routes/[id]/IDE.svelte
@@ -58,7 +58,7 @@
 
 	const runCode = async () => {
 		const code = mainEditor?.getValue();
-		const input = inputEditor?.getValue();
+		const input = inputEditor?.getValue().trimEnd();
 
 		if (code === undefined || input === undefined) {
 			console.warn('Code or input is undefined when trying to run code, cancelling', code, input);


### PR DESCRIPTION
Trimmed trailing spaces in getline input to avoid formatting issue #192 

Added `trimEnd()` to `const input = inputEditor?.getValue().trimEnd();` in IDE.svelte
Now, any accidental extra spaces are removed from the input.